### PR TITLE
JH-81 -- update all community docs with internal 7.4.0 documentation ...

### DIFF
--- a/doc/cloud-discovery-service/README.md
+++ b/doc/cloud-discovery-service/README.md
@@ -1,6 +1,6 @@
 Welcome to *RTI® Cloud Discovery Service*, an *RTI Connext®* out-of-the-box solution for provisioning discovery in cloud-based environments where multicast may not be available.
 
-For additional information on *RTI Cloud Discovery Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/addon_products/cloud_discovery_service/index.html).
+For additional information on *RTI Cloud Discovery Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/addon_products/cloud_discovery_service/index.html).
 
 The documentation shown on this page applies to the *Cloud Discovery Service* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -11,7 +11,7 @@ Running *Cloud Discovery Service* on Docker is as simple as running the ``docker
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=cloud_discovery_service \
         rticom/cloud-discovery-service:latest \
         -cfgName default
@@ -28,7 +28,7 @@ export NDDS_DISCOVERY_PEERS=rtps@udpv4://216.58.194.174:7400
 To run *Cloud Discovery Service*, you will need an RTI license file. Bind-mount your license from the host by using the following command-line parameter:
 
 ```
--v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The *Cloud Discovery Service* container image uses the following user and group:
@@ -38,14 +38,14 @@ The *Cloud Discovery Service* container image uses the following user and group:
 
 The *Cloud Discovery Service* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/cloud_discovery_service```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/cloud_discovery_service```
 
 ## Built-in configuration
 
 Use the following command to retrieve the *Cloud Discovery Service* built-in configuration file:
 
 ```
-docker cp cloud_discovery_service:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_CLOUD_DISCOVERY_SERVICE.xml .
+docker cp cloud_discovery_service:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_CLOUD_DISCOVERY_SERVICE.xml .
 ```
 
 The built-in configuration supports the following execution modes:
@@ -60,7 +60,7 @@ To select an execution mode, pass the ``-cfgName`` parameter with the desired co
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=cloud_discovery_service \
         rticom/cloud-discovery-service:latest \
         -cfgName defaultWAN
@@ -80,7 +80,7 @@ To provide your own configuration, follow these steps when running the container
 
 * bind-mount your configuration file (for example, MyCloudDiscoveryService.xml) from the host 
 into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/cloud_discovery_service/USER_CLOUD_DISCOVERY_SERVICE.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/cloud_discovery_service/USER_CLOUD_DISCOVERY_SERVICE.xml```
 * select the *Cloud Discovery Service* configuration in the configuration file by adding the ``-cfgName``
 parameter with the name of your selected configuration
 
@@ -89,8 +89,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyCloudDiscoveryService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/cloud_discovery_service/USER_CLOUD_DISCOVERY_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyCloudDiscoveryService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/cloud_discovery_service/USER_CLOUD_DISCOVERY_SERVICE.xml \
         --name=cloud_discovery_service \
         rticom/cloud-discovery-service:latest \
         -cfgName MyCloudDiscoveryService
@@ -104,8 +104,8 @@ them to the end of the ``docker run`` command. For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyCloudDiscoveryService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/cloud_discovery_service/USER_CLOUD_DISCOVERY_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyCloudDiscoveryService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/cloud_discovery_service/USER_CLOUD_DISCOVERY_SERVICE.xml \
         --name=cloud_discovery_service \
         rticom/cloud-discovery-service:latest \
         -cfgName MyCloudDiscoveryService \
@@ -126,7 +126,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use RTI Real-Time WAN Transport and expose the necessary UDP ports using the `-p` option. For more information on RTI Real-Time WAN Transport, refer to the [RTI Real-Time WAN Transport documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use RTI Real-Time WAN Transport and expose the necessary UDP ports using the `-p` option. For more information on RTI Real-Time WAN Transport, refer to the [RTI Real-Time WAN Transport documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 The built-in ``defaultWAN`` configuration uses RTI Real-Time WAN Transport.
 
@@ -147,7 +147,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp cloud_discovery_service:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp cloud_discovery_service:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/collector-service/README.md
+++ b/doc/collector-service/README.md
@@ -3,7 +3,7 @@
 (metrics and logs) from *Connext* applications and stores this data in third-party 
 observability backends.
 
-In the *Connext* 7.3.0 release, *Collector Service* provides native integration
+*Collector Service* provides native integration
 with Prometheus®, as the time-series database to store Connext metrics, and Grafana® 
 Loki™, as the log aggregation system to store Connext logs. Integration with other 
 backends is possible using 
@@ -11,7 +11,7 @@ backends is possible using
 [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/).
 
 For additional information on *RTI Connext Observability Framework*, see the 
-[RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/addon_products/observability/index.html#).
+[RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/addon_products/observability/index.html#).
 
 The documentation shown on this page applies to the *Collector Service* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -22,14 +22,14 @@ Running *Collector Service* on Docker is as simple as running the ``docker run``
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=collector_service \
         rticom/collector-service:latest
 ```
 
 The above command starts *Collector Service* with a default configuration 
 that stores the metrics and logs emitted by *Connext* applications using 
-[Connext Monitoring Library 2.0](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/addon_products/observability/library.html)
+[Connext Monitoring Library 2.0](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/addon_products/observability/library.html)
 on domain ID 2 into Prometheus (for metrics) and Grafana Loki (for logs) 
 databases .
 
@@ -42,7 +42,7 @@ container. Bind-mount your license from the host by using the following
 command-line parameter:
 
 ```
--v /path/to/your_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v /path/to/your_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The *Collector Service* container image uses the following user and group:
@@ -52,7 +52,7 @@ The *Collector Service* container image uses the following user and group:
 
 The *Collector Service* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/collector_service```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/collector_service```
 
 The following table indicates the RTI licenses required based on your answers 
 to the questions in the first two columns.
@@ -69,7 +69,7 @@ to the questions in the first two columns.
 The built-in configuration file used by *Collector Service* can be retrieved using the following command:
 
 ```
-docker cp collector_service:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_COLLECTOR_SERVICE.xml .
+docker cp collector_service:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_COLLECTOR_SERVICE.xml .
 ```
 The built-in configuration supports the following execution modes:
 
@@ -101,7 +101,7 @@ mode, set the environment variable ``CFG_NAME`` to *SecureLAN*.
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         -e CFG_NAME="SecureLAN" \
         --name=collector_service \
         rticom/collector-service:latest
@@ -172,7 +172,7 @@ follows:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         -e CFG_NAME="NonSecureWAN" \
         -e OBSERVABILITY_DOMAIN=33 \
         -e OBSERVABILITY_RWT_PUBLIC_ADDRESS=10.10.1.34 \
@@ -208,7 +208,7 @@ Service*.
 * *permissions.p7s* must contain the permissions file of the *Collector Service*.
 
 For additional information on how to generate these security artifacts, see
-[Generating the Observability Framework Security Artifacts](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/addon_products/observability/security.html#generating-the-observability-framework-security-artifacts).
+[Generating the Observability Framework Security Artifacts](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/addon_products/observability/security.html#generating-the-observability-framework-security-artifacts).
 
 **To configure HTTPS + Basic Authentication:**
 
@@ -255,7 +255,7 @@ files listed above. For example, if you are not running OpenTelemetry Collector,
 you do not need to provide *rootCAOtel.crt*.
 
 For additional information on how to generate these security artifacts, see
-[Generating the Observability Framework Security Artifacts](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/addon_products/observability/security.html#generating-the-observability-framework-security-artifacts).
+[Generating the Observability Framework Security Artifacts](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/addon_products/observability/security.html#generating-the-observability-framework-security-artifacts).
 
 ## Custom configuration
 
@@ -268,7 +268,7 @@ To provide your own configuration, follow these steps when running the container
 
 * bind-mount your configuration file (for example, MyCollectorService.xml) from the host 
 into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/collector_service/USER_COLLECTOR_SERVICE.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/collector_service/USER_COLLECTOR_SERVICE.xml```
 * select the *Collector Service* configuration in the configuration file by 
 setting the ``CFG_NAME`` environment variable
 
@@ -277,8 +277,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyCollectorService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/collector_service/USER_COLLECTOR_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyCollectorService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/collector_service/USER_COLLECTOR_SERVICE.xml \
         -e CFG_NAME="MyCollectorService" \
         --name=collector_service \
         rticom/collector-service:latest
@@ -292,8 +292,8 @@ them to the end of the ``docker run`` command. For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyCollectorService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/collector_service/USER_COLLECTOR_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyCollectorService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/collector_service/USER_COLLECTOR_SERVICE.xml \
         -e CFG_NAME="MyCollectorService" \
         --name=collector_service \
         rticom/collector-service:latest \
@@ -316,7 +316,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use RTI Real-Time WAN Transport and expose the necessary UDP ports using the `-p` option. For more information on RTI Real-Time WAN Transport, refer to the [RTI Real-Time WAN Transport documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use RTI Real-Time WAN Transport and expose the necessary UDP ports using the `-p` option. For more information on RTI Real-Time WAN Transport, refer to the [RTI Real-Time WAN Transport documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 The following built-in configuration modes use the RTI Real-Time WAN Transport:
 * SecureWAN
@@ -341,7 +341,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp collector_service:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp collector_service:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/dds-ping/README.md
+++ b/doc/dds-ping/README.md
@@ -1,6 +1,6 @@
 Welcome to *RTI® DDS Ping*, an *RTI Connext®* command-line utility that is invaluable for debugging issues with DDS applications. It sends and receives simple "ping" messages using *Connext*, which can help determine whether there are issues with discovery or misconfiguration in the DDS communication between applications.
 
-For additional information on *RTI DDS Ping*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/tools/rti_dds_ping/introduction.html).
+For additional information on *RTI DDS Ping*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/tools/rti_dds_ping/introduction.html).
 
 The documentation shown on this page applies to the *DDS Ping* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -23,7 +23,7 @@ docker run -t \
 You should see output similar to the following:
 
 ```sh
-RTI Connext DDS Ping built with DDS version: 7.3.0
+RTI Connext DDS Ping built with DDS version: 7.4.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sending data...   value: 0000000 
 Sending data...   value: 0000001 
@@ -46,7 +46,7 @@ docker run -t \
 You should see output similar to the following:
 
 ```
-RTI Connext DDS Ping built with DDS version: 7.3.0
+RTI Connext DDS Ping built with DDS version: 7.4.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 rtiddsping, issue received: 0000000
 rtiddsping, issue received: 0000001
@@ -69,13 +69,13 @@ The *DDS Ping* container image uses the following user and group:
 
 The *DDS Ping* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/ping```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/ping```
 
 ## Built-in configuration
 Use the following command to retrieve the *DDS Ping* built-in configuration file:
 
 ```
-docker cp dds_ping_publisher:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_DDS_PING_QOS_PROFILES.xml .
+docker cp dds_ping_publisher:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_DDS_PING_QOS_PROFILES.xml .
 ```
 
 The built-in configuration uses the built-in transports UDPv4 and SHMEM, and publishes and subscribes using best effort reliability.
@@ -84,7 +84,7 @@ The built-in configuration uses the built-in transports UDPv4 and SHMEM, and pub
 To provide your own configuration, follow these steps when running the container:
 
 * bind-mount your QoS configuration file from the host into the following location in the Docker container:
-```/home/rtiuser/rti_workspace/7.3.0/user_config/ping/USER_DDS_PING_QOS_PROFILES.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/ping/USER_DDS_PING_QOS_PROFILES.xml```
 * select the *DDS Ping* QoS configuration file by adding the ``-qosFile`` parameter with the name of your mounted QoS configuration file
 * select the configuration profile by adding the ``-qosProfile`` parameter with the name of the profile you want to use
 
@@ -93,7 +93,7 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/MyQOSProfiles.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/ping/USER_DDS_PING_QOS_PROFILES.xml \
+        -v $PWD/MyQOSProfiles.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/ping/USER_DDS_PING_QOS_PROFILES.xml \
         --name=dds_ping_publisher \
         rticom/dds-ping:latest \
         -qosFile USER_DDS_PING_QOS_PROFILES.xml
@@ -131,7 +131,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 This image does not provide built-in configuration for *RTI Real-Time WAN Transport*. If you want to use it, you will need to provide your own configuration file.
 
@@ -152,7 +152,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp dds_ping:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp dds_ping:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/dds-spy/README.md
+++ b/doc/dds-spy/README.md
@@ -1,6 +1,6 @@
 Welcome to *RTI® DDS Spy*, an *RTI Connext®* tool that allows developers to monitor DDS traffic within a domain. This tool helps in debugging and analyzing real-time data published in the DDS network.
 
-For additional information on *RTI DDS Spy*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/tools/rti_dds_spy/introduction.html).
+For additional information on *RTI DDS Spy*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/tools/rti_dds_spy/introduction.html).
 
 The documentation shown on this page applies to the *DDS Spy* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -25,7 +25,7 @@ The *DDS Spy* container image uses the following user and group:
 
 The *DDS Spy* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/spy```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/spy```
 
 
 ## Built-in configuration
@@ -33,7 +33,7 @@ The *DDS Spy* container image uses the following working directory:
 Use the following command to retrieve the *DDS Spy* built-in QoS configuration file:
 
 ```
-docker cp dds_spy:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_DDS_SPY_QOS_PROFILES.xml .
+docker cp dds_spy:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_DDS_SPY_QOS_PROFILES.xml .
 ```
 
 ## Custom configuration
@@ -41,7 +41,7 @@ To provide your own configuration, follow these steps when running the container
 
 * bind-mount your QoS configuration file from the host
 into the following location in the Docker container: 
-``/home/rtiuser/rti_workspace/7.3.0/user_config/spy/USER_DDS_SPY_QOS_PROFILES.xml``
+``/home/rtiuser/rti_workspace/7.4.0/user_config/spy/USER_DDS_SPY_QOS_PROFILES.xml``
 * select the *DDS Spy* QoS configuration file by adding the ``-qosFile``
 parameter with the name of your mounted QoS configuration file
 
@@ -50,7 +50,7 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/MyQOSProfiles.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/spy/USER_DDS_SPY_QOS_PROFILES.xml \
+        -v $PWD/MyQOSProfiles.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/spy/USER_DDS_SPY_QOS_PROFILES.xml \
         --name=dds_spy \
         rticom/dds-spy:latest \
         -domainId 0 \
@@ -87,7 +87,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 This image does not provide built-in configuration for *RTI Real-Time WAN Transport*. If you want to use it, you will need to provide your own configuration file.
 
@@ -108,7 +108,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp dds_spy:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp dds_spy:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/perftest/README.md
+++ b/doc/perftest/README.md
@@ -15,7 +15,7 @@ The following command runs *Perftest* as a publisher with a data length of 1024 
 ```
 docker run -t \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=perftest_pub \
         rticom/perftest:latest \
         -pub -dataLen 1024 -executionTime 60
@@ -37,7 +37,7 @@ The following command runs *Perftest* as a subscriber with a data length of 1024
 ```
 docker run -t \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=perftest_sub \
         rticom/perftest:latest \
         -sub -dataLen 1024
@@ -64,7 +64,7 @@ docker logs perftest_sub
 To run *Perftest*, you will need an RTI license file. Bind-mount your license from the host by using the following command-line parameter:
 
 ```
--v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The *Perftest* container image uses the following user and group:
@@ -74,14 +74,14 @@ The *Perftest* container image uses the following user and group:
 
 The *Perftest* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/perftest```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/perftest```
 
 ## Built-in Configuration
 
 Use the following command to retrieve the *Perftest* built-in configuration file:
 
 ```
-docker cp perftest:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_PERFTEST.xml .
+docker cp perftest:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_PERFTEST.xml .
 ```
 
 ## Custom Configuration
@@ -90,7 +90,7 @@ To provide your own configuration, follow these steps when running the container
 
 * bind-mount your configuration file from the host
 into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/perftest/USER_PERFTEST_CONFIG.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/perftest/USER_PERFTEST_CONFIG.xml```
 * select the *Perftest* configuration in the configuration file by adding the ```-cfgName``` parameter with the name of your selected configuration 
 
 For example:
@@ -98,8 +98,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyPerftestConfig.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/perftest/USER_PERFTEST_CONFIG.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyPerftestConfig.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/perftest/USER_PERFTEST_CONFIG.xml \
         --name=perftest \
         rticom/perftest:latest \
         -cfgName MyPerftestConfig
@@ -113,7 +113,7 @@ them to the end of the ``docker run`` command. For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=perftest \
         rticom/perftest:latest \
         -pub -dataLen 1024 -executionTime 60 -verbosity WARN
@@ -140,7 +140,7 @@ The following examples run a basic throughput test.
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=perftest_pub \
         rticom/perftest:latest \
         -pub -dataLen 1024 -executionTime 60
@@ -150,7 +150,7 @@ docker run -dt \
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=perftest_sub \
         rticom/perftest:latest \
         -sub -dataLen 1024
@@ -167,7 +167,7 @@ The following examples run a latency test.
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=perftest_pub \
         rticom/perftest:latest \
         -pub -latencyTest -dataLen 1024 -executionTime 60
@@ -178,7 +178,7 @@ docker run -dt \
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=perftest_sub \
         rticom/perftest:latest \
         -sub -dataLen 1024
@@ -190,7 +190,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 *Perftest* allows configuring the transport properties using the `-transport` parameter. For more information on the `-transport` parameter, refer to the [RTI Perftest transport-specific options documentation](https://community.rti.com/static/documentation/perftest/4.1.1/command_line_parameters.html#transport-specific-options).
 
@@ -211,7 +211,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp perftest:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp perftest:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/persistence-service/README.md
+++ b/doc/persistence-service/README.md
@@ -1,7 +1,7 @@
 Welcome to *RTI® Persistence Service*, an *RTI Connext®* application designed to persist DDS *Topic* data. It ensures that data produced by a *DataWriter* can survive beyond the lifetime of the *DataWriter* itself, making it available to late-joining *DataReaders* that require data with TRANSIENT or PERSISTENT durability.
 
 For additional information on *RTI Persistence Service*, refer to the 
-[RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartPersistence.htm).
+[RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartPersistence.htm).
 
 The documentation shown on this page applies to the *Persistence Service* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -12,7 +12,7 @@ Running _Persistence Service_ on Docker is as simple as running the ``docker run
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=persistence_service \
         rticom/persistence-service:latest \
         -cfgName default
@@ -23,7 +23,7 @@ This command starts _Persistence Service_ with an example configuration that per
 To run _Persistence Service_, you will need an RTI license file. Bind-mount your license from the host by using the following command-line parameter:
 
 ```
--v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The _Persistence Service_ container image uses the following user and group:
@@ -33,14 +33,14 @@ The _Persistence Service_ container image uses the following user and group:
 
 The _Persistence Service_ container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/persistence_service```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/persistence_service```
 
 ## Built-in configuration
 
 Use the following command to retrieve the _Persistence Service_ built-in configuration file:
 
 ```
-docker cp persistence_service:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_PERSISTENCE_SERVICE.xml .
+docker cp persistence_service:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_PERSISTENCE_SERVICE.xml .
 ```
 
 The built-in configuration supports the following execution modes:
@@ -55,7 +55,7 @@ To select an execution mode, pass the ``-cfgName`` parameter with the desired co
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=persistence_service \
         rticom/persistence-service:latest \
         -cfgName defaultDisk
@@ -68,12 +68,12 @@ When running the Docker container built-in configurations, there are several par
 ```
 -e ADMINISTRATION_DOMAIN=<The domain ID Persistence Service uses for administration. default: 0>
 -e DATA_DOMAIN=<The domain ID Persistence Service uses for the user data. default: 0>
--e STORAGE_DIRECTORY=<The folder where the database file(s) are going to be generated. default: /home/rtiuser/rti_workspace/7.3.0/database>
+-e STORAGE_DIRECTORY=<The folder where the database file(s) are going to be generated. default: /home/rtiuser/rti_workspace/7.4.0/database>
 ```
 
 ### Database files storage with defaultDisk using default storage directory
 
-The ``defaultDisk`` configuration stores the database files in  ``/home/rtiuser/rti_workspace/7.3.0/database``. Without additional configuration parameters, the files created in this directory are not persisted across container restarts.
+The ``defaultDisk`` configuration stores the database files in  ``/home/rtiuser/rti_workspace/7.4.0/database``. Without additional configuration parameters, the files created in this directory are not persisted across container restarts.
 
 To persist data across container restarts, you have two options:
 * bind-mount a directory from the host to the database directory
@@ -86,8 +86,8 @@ To persist data across container restarts, you have two options:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        --mount type=volume,source=persistence_service_database,target=/home/rtiuser/rti_workspace/7.3.0/database \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        --mount type=volume,source=persistence_service_database,target=/home/rtiuser/rti_workspace/7.4.0/database \
         --name=persistence_service \
         rticom/persistence-service:latest \
         -cfgName defaultDisk
@@ -100,8 +100,8 @@ It is not necessary to create the volume ``persistence_service_database``. Docke
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/persistence_service_database:/home/rtiuser/rti_workspace/7.3.0/database \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/persistence_service_database:/home/rtiuser/rti_workspace/7.4.0/database \
         --name=persistence_service \
         rticom/persistence-service:latest \
         -cfgName defaultDisk
@@ -154,7 +154,7 @@ sudo chown -R 1000:1000 /var/lib/docker/volumes/persistence_service_database/_da
    ```
    docker run -dt \
            --network host \
-           -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+           -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
            --mount type=volume,source=persistence_service_database,target=/home/rtiuser/database \
            -e STORAGE_DIRECTORY=/home/rtiuser/database \
            --name=persistence_service \
@@ -167,7 +167,7 @@ sudo chown -R 1000:1000 /var/lib/docker/volumes/persistence_service_database/_da
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         -v $PWD/persistence_service_database:/home/rtiuser/database \
         -e STORAGE_DIRECTORY=/home/rtiuser/database \
         --name=persistence_service \
@@ -182,7 +182,7 @@ docker run -dt \
 To provide your own configuration, follow these steps when running the container:
 
 * bind-mount your configuration file (for example, MyPersistenceService.xml) from the host into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/persistence_service/USER_PERSISTENCE_SERVICE.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/persistence_service/USER_PERSISTENCE_SERVICE.xml```
 * select the _Persistence Service_ configuration in the configuration file by adding the ``-cfgName``
 parameter with the name of your selected configuration
 
@@ -191,8 +191,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyPersistenceService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/persistence_service/USER_PERSISTENCE_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyPersistenceService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/persistence_service/USER_PERSISTENCE_SERVICE.xml \
         --name=persistence_service \
         rticom/persistence-service:latest \
         -cfgName MyPersistenceService
@@ -205,8 +205,8 @@ To provide your command-line parameters to _Persistence Service_, add them to th
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyPersistenceService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/persistence_service/USER_PERSISTENCE_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyPersistenceService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/persistence_service/USER_PERSISTENCE_SERVICE.xml \
         --name=persistence_service \
         rticom/persistence-service:latest \
         -cfgName MyPersistenceService \
@@ -226,7 +226,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transpor*t and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transpor*t and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 This image does not provide built-in configuration for *RTI Real-Time WAN Transport*. If you want to use it, you will need to provide your own configuration file.
 
@@ -247,7 +247,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp persistence_service:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp persistence_service:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/recording-service/README.md
+++ b/doc/recording-service/README.md
@@ -1,6 +1,6 @@
 Welcome to *RTI® Recording Service*, an *RTI Connext®* application that records DDS *Topics* and discovery data.
 
-For additional information on *RTI Recording Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/services/recording_service/index.html).
+For additional information on *RTI Recording Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/services/recording_service/index.html).
 
 The documentation shown on this page applies to the *Recording Service* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -11,18 +11,18 @@ Running *Recording Service* on Docker is as simple as running the ``docker run``
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=recording_service \
         rticom/recording-service:latest \
         -cfgName default
 ```
 
-This command starts *Recording Service* with an example configuration that records all _Topics_ in domain 0. The database files are going to be created in  ```/home/rtiuser/rti_workspace/7.3.0/database/```.
+This command starts *Recording Service* with an example configuration that records all _Topics_ in domain 0. The database files are going to be created in  ```/home/rtiuser/rti_workspace/7.4.0/database/```.
 
 To run *Recording Service*, you will need an RTI license file. Bind-mount your license from the host by using the following command-line parameter:
 
 ```
--v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The *Recording Service* container image uses the following user and group:
@@ -32,14 +32,14 @@ The *Recording Service* container image uses the following user and group:
 
 The *Recording Service* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/recording_service```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/recording_service```
 
 ## Built-in configuration
 
 Use the following command to retrieve the *Recording Service* built-in configuration file:
 
 ```
-docker cp recording_service:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_RECORDING_SERVICE.xml .
+docker cp recording_service:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_RECORDING_SERVICE.xml .
 ```
 
 The built-in configuration supports the following execution modes:
@@ -54,7 +54,7 @@ To select an execution mode, pass the ``-cfgName`` parameter with the desired co
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=recording_service \
         rticom/recording-service:latest \
         -cfgName default
@@ -74,7 +74,7 @@ using environment variables:
 
 ### Database files storage using default storage directory
 
-The default and defaultJson configurations store the database files in ``/home/rtiuser/rti_workspace/7.3.0/database``. Without additional configuration parameters, the files created in this directory are not persisted across container restarts.
+The default and defaultJson configurations store the database files in ``/home/rtiuser/rti_workspace/7.4.0/database``. Without additional configuration parameters, the files created in this directory are not persisted across container restarts.
 
 To persist data across container restarts, you have two options: 
 * bind-mount a directory from the host to the database directory
@@ -87,8 +87,8 @@ The second option is recommended for persisting the database files across contai
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        --mount type=volume,source=recording_service_database,target=/home/rtiuser/rti_workspace/7.3.0/database \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        --mount type=volume,source=recording_service_database,target=/home/rtiuser/rti_workspace/7.4.0/database \
         --name=recording_service \
         rticom/recording-service:latest \
         -cfgName default
@@ -101,8 +101,8 @@ It is not necessary to create the volume ``recording_service_database``. Docker 
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/recording_service_database:/home/rtiuser/rti_workspace/7.3.0/database \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/recording_service_database:/home/rtiuser/rti_workspace/7.4.0/database \
         --name=recording_service \
         rticom/recording-service:latest \
         -cfgName default
@@ -154,7 +154,7 @@ You will see the mount point in the Mountpoint field. For example:
    ```
    docker run -dt \
            --network host \
-           -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+           -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
            --mount type=volume,source=recording_service_database,target=/home/rtiuser/database \
            -e WORKSPACE_DIR=/home/rtiuser/database \
            --name=recording_service \
@@ -167,7 +167,7 @@ You will see the mount point in the Mountpoint field. For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         -v $PWD/recording_service_database:/home/rtiuser/database \
         -e WORKSPACE_DIR=/home/rtiuser/database \
         --name=recording_service \
@@ -214,7 +214,7 @@ sudo chown -R 1000:1000 /var/lib/docker/volumes/recording_service_database/_data
 To provide your own configuration, follow these steps when running the container:
 
 * bind-mount your configuration file (for example, MyRecordingService.xml) from the host into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/recording_service/USER_RECORDING_SERVICE.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/recording_service/USER_RECORDING_SERVICE.xml```
 * select the *Recording Service* configuration in the configuration file by adding the ``-cfgName`` parameter with the name of your selected configuration
 
 For example:
@@ -222,8 +222,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyRecordingService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/recording_service/USER_RECORDING_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyRecordingService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/recording_service/USER_RECORDING_SERVICE.xml \
         --name=recording_service \
         rticom/recording-service:latest \
         -cfgName MyRecordingService
@@ -236,8 +236,8 @@ To provide your command-line parameters to *Recording Service*, add them to the 
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyRecordingService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/recording_service/USER_RECORDING_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyRecordingService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/recording_service/USER_RECORDING_SERVICE.xml \
         --name=recording_service \
         rticom/recording-service:latest \
         -cfgName MyRecordingService \
@@ -258,7 +258,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 This image does not provide built-in configuration for *RTI Real-Time WAN Transport*. If you want to use it, you will need to provide your own configuration file.
 
@@ -279,7 +279,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp recording_service:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp recording_service:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/replay-service/README.md
+++ b/doc/replay-service/README.md
@@ -1,6 +1,6 @@
 Welcome to *RTI® Replay Service*, an *RTI Connext®* application that replays DDS *Topics* and discovery data previously recorded by the *RTI Recording Service*.
 
-For additional information on *RTI Replay Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/services/recording_service/replay/replay_index.html).
+For additional information on *RTI Replay Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/services/recording_service/replay/replay_index.html).
 
 The documentation shown on this page applies to the *Replay Service* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -11,18 +11,18 @@ Running *Replay Service* on Docker is as simple as running the ``docker run`` co
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=replay_service \
         rticom/replay-service:latest \
         -cfgName default
 ```
 
-This command starts *Replay Service* with an example configuration that replays a record that should be in the database files located in  ```/home/rtiuser/rti_workspace/7.3.0/database/```. The following sections explain the different ways to provide the database files.
+This command starts *Replay Service* with an example configuration that replays a record that should be in the database files located in  ```/home/rtiuser/rti_workspace/7.4.0/database/```. The following sections explain the different ways to provide the database files.
 
 To run *Replay Service*, you will need an RTI license file. Bind-mount your license from the host by using the following command-line parameter:
 
 ```
--v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The *Replay Service* container image uses the following user and group:
@@ -32,14 +32,14 @@ The *Replay Service* container image uses the following user and group:
 
 The *Replay Service* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/replay_service```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/replay_service```
 
 ## Built-in configuration
 
 Use the following command to retrieve the *Replay Service* built-in configuration file:
 
 ```
-docker cp replay_service:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_REPLAY_SERVICE.xml .
+docker cp replay_service:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_REPLAY_SERVICE.xml .
 ```
 
 The built-in configuration supports the following execution mode:
@@ -53,7 +53,7 @@ To select an execution mode, pass the ``-cfgName`` parameter with the desired co
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=replay_service \
         rticom/replay-service:latest \
         -cfgName default
@@ -73,7 +73,7 @@ using environment variables:
 
 ### Database files storage using default storage directory
 
-The default configuration takes the database files from ```/home/rtiuser/rti_workspace/7.3.0/database/cdr_recording```. Take into account that the database files are not in the container’s filesystem. To test this image, you can use the *RTI Recording Service* Docker image to record some data, and then use the *RTI Replay Service* image to replay it.
+The default configuration takes the database files from ```/home/rtiuser/rti_workspace/7.4.0/database/cdr_recording```. Take into account that the database files are not in the container’s filesystem. To test this image, you can use the *RTI Recording Service* Docker image to record some data, and then use the *RTI Replay Service* image to replay it.
 
 You can use the following two options to provide the database files:
 * bind-mount a directory from the host to the database directory
@@ -86,8 +86,8 @@ The second option is recommended for persisting the database files across contai
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        --mount type=volume,source=recording_service_database,target=/home/rtiuser/rti_workspace/7.3.0/database \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        --mount type=volume,source=recording_service_database,target=/home/rtiuser/rti_workspace/7.4.0/database \
         --name=replay_service \
         rticom/replay-service:latest \
         -cfgName default
@@ -100,8 +100,8 @@ The ``recording_service_database`` volume should contain the database files in X
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/recording_service_database:/home/rtiuser/rti_workspace/7.3.0/database \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/recording_service_database:/home/rtiuser/rti_workspace/7.4.0/database \
         --name=replay_service \
         rticom/replay-service:latest \
         -cfgName default
@@ -146,7 +146,7 @@ sudo chown -R 1000:1000 /var/lib/docker/volumes/recording_service_database/_data
    ```
    docker run -dt \
            --network host \
-           -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+           -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
            --mount type=volume,source=recording_service_database,target=/home/rtiuser/database \
            -e DATABASE_DIR=/home/rtiuser/database/cdr_recording \
            --name=replay_service \
@@ -159,7 +159,7 @@ sudo chown -R 1000:1000 /var/lib/docker/volumes/recording_service_database/_data
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         -v $PWD/recording_service_database:/home/rtiuser/database \
         -e DATABASE=/home/rtiuser/database/cdr_recording \
         --name=replay_service \
@@ -206,7 +206,7 @@ sudo chown -R 1000:1000 /var/lib/docker/volumes/recording_service_database/_data
 To provide your own configuration, follow these steps when running the container:
 
 * bind-mount your configuration file (for example, MyReplayService.xml) from the host into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/replay_service/USER_REPLAY_SERVICE.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/replay_service/USER_REPLAY_SERVICE.xml```
 * select the *Replay Service* configuration in the configuration file by adding the ``-cfgName`` parameter with the name of your selected configuration
 
 For example:
@@ -214,8 +214,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyReplayService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/replay_service/USER_REPLAY_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyReplayService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/replay_service/USER_REPLAY_SERVICE.xml \
         --name=replay_service \
         rticom/replay-service:latest \
         -cfgName MyReplayService
@@ -228,8 +228,8 @@ To provide your command-line parameters to *Replay Service*, add them to the end
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyReplayService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/replay_service/USER_REPLAY_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyReplayService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/replay_service/USER_REPLAY_SERVICE.xml \
         --name=replay_service \
         rticom/replay-service:latest \
         -cfgName MyReplayService \
@@ -250,7 +250,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use RTI Real-Time WAN Transport and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use RTI Real-Time WAN Transport and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 This image does not provide built-in configuration for *RTI Real-Time WAN Transport*. If you want to use it, you will need to provide your own configuration file.
 
@@ -271,7 +271,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp replay_service:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp replay_service:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/routing-service/README.md
+++ b/doc/routing-service/README.md
@@ -1,6 +1,6 @@
 Welcome to *RTI® Routing Service*, an *RTI Connext®* out-of-the-box solution that allows developers to rapidly scale and integrate real-time systems that are disparate or geographically dispersed. It scales *RTI Connext* applications across domains, LANs, and WANs, including firewall and NAT traversal.
 
-For additional information on *RTI Routing Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/services/routing_service/index.html).
+For additional information on *RTI Routing Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/services/routing_service/index.html).
 
 The documentation shown on this page applies to the *Routing Service* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -11,7 +11,7 @@ Running *Routing Service* on Docker is as simple as running the ``docker run`` c
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=routing_service \
         rticom/routing-service:latest \
         -cfgName DomainBridgingLAN
@@ -22,7 +22,7 @@ This command starts *Routing Service* with a sample configuration that routes al
 To run *Routing Service*, you will need an RTI license file. Bind-mount your license from the host by using the following command-line parameter:
 
 ```
--v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The *Routing Service* container image uses the following user and group:
@@ -32,14 +32,14 @@ The *Routing Service* container image uses the following user and group:
 
 The *Routing Service* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/routing_service```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/routing_service```
 
 ## Built-in configuration
 
 Use the following command to retrieve the *Routing Service* built-in configuration file:
 
 ```
-docker cp routing_service:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_ROUTING_SERVICE.xml .
+docker cp routing_service:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_ROUTING_SERVICE.xml .
 ```
 
 The built-in configuration supports the following execution modes:
@@ -61,7 +61,7 @@ To select an execution mode, pass the ``-cfgName`` parameter with the desired co
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=routing_service \
         rticom/routing-service:latest \
         -cfgName RelayWAN
@@ -99,7 +99,7 @@ To provide your own configuration, follow these steps when running the container
 
 * bind-mount your configuration file (for example, MyRoutingService.xml) from the host 
 into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/routing_service/USER_ROUTING_SERVICE.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/routing_service/USER_ROUTING_SERVICE.xml```
 * select the *Routing Service* configuration in the configuration file by adding the ``-cfgName``
 parameter with the name of your selected configuration
 
@@ -108,8 +108,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyRoutingService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/routing_service/USER_ROUTING_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyRoutingService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/routing_service/USER_ROUTING_SERVICE.xml \
         --name=routing_service \
         rticom/routing-service:latest \
         -cfgName MyRoutingService
@@ -123,8 +123,8 @@ them to the end of the ``docker run`` command. For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyRoutingService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/routing_service/USER_ROUTING_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyRoutingService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/routing_service/USER_ROUTING_SERVICE.xml \
         --name=routing_service \
         rticom/routing-service:latest \
         -cfgName MyRoutingService \
@@ -145,7 +145,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, the recommendation is to use *RTI Real-Time WAN Transport* and expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 This image provides a built-in configuration for *RTI Real-Time WAN Transport* called *RelayWAN*. You can also provide additional configurations for the *RTI Real-Time WAN Transport* by using your own configuration file.
 
@@ -166,7 +166,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp routing_service:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp routing_service:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file

--- a/doc/web-integration-service/README.md
+++ b/doc/web-integration-service/README.md
@@ -1,6 +1,6 @@
 Welcome to *RTI® Web Integration Service*, an *RTI Connext®* out-of-the-box solution for integrating web-based applications and services with *RTI Connext*.
 
-For additional information on *RTI Web Integration Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/services/web_integration_service/index.html).
+For additional information on *RTI Web Integration Service*, refer to the [RTI documentation](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/services/web_integration_service/index.html).
 
 The documentation shown on this page applies to the *Web Integration Service* Docker image with the `latest` tag. The latest tag refers to the most recent Long Term Support (LTS) version released from RTI. For specific tag documentation, refer to the https://github.com/rticommunity/rticonnextdds-containers repository.
 
@@ -11,11 +11,11 @@ Running *Web Integration Service* on Docker is as simple as running the ``docker
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
         --name=web_integration_service \
         rticom/web-integration-service:latest \
         -cfgName shapesDemoTutorial \
-        -documentRoot /home/rtiuser/rti_workspace/7.3.0/examples/web_integration_service
+        -documentRoot /home/rtiuser/rti_workspace/7.4.0/examples/web_integration_service
 ```
 
 This command starts an instance of *Web Integration Service* in [localhost](http://localhost:8080). By default, *Web Integration Service* listens for HTTP requests on port 8080.
@@ -23,7 +23,7 @@ This command starts an instance of *Web Integration Service* in [localhost](http
 To run *Web Integration Service*, you will need an RTI license file. Bind-mount your license from the host by using the following command-line parameter:
 
 ```
--v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat
+-v $PWD/your/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat
 ```
 
 The *Web Integration Service* container image uses the following user and group:
@@ -33,14 +33,14 @@ The *Web Integration Service* container image uses the following user and group:
 
 The *Web Integration Service* container image uses the following working directory:
 
-* ```/home/rtiuser/rti_workspace/7.3.0/user_config/web_integration_service```
+* ```/home/rtiuser/rti_workspace/7.4.0/user_config/web_integration_service```
 
 ## Built-in configuration
 
 Use the following command to retrieve the *Web Integration Service* built-in configuration file:
 
 ```
-docker cp web_integration_service:/opt/rti.com/rti_connext_dds-7.3.0/resource/xml/RTI_WEB_INTEGRATION_SERVICE.xml
+docker cp web_integration_service:/opt/rti.com/rti_connext_dds-7.4.0/resource/xml/RTI_WEB_INTEGRATION_SERVICE.xml
 ```
 
 The built-in configuration provides the following execution mode:
@@ -55,7 +55,7 @@ To provide your own configuration, follow these steps when running the container
 
 * bind-mount your configuration file (for example, MyWebIntegrationService.xml) from the host 
 into the following location in the Docker container: 
-```/home/rtiuser/rti_workspace/7.3.0/user_config/web_integration_service/USER_WEB_INTEGRATION_SERVICE.xml```
+```/home/rtiuser/rti_workspace/7.4.0/user_config/web_integration_service/USER_WEB_INTEGRATION_SERVICE.xml```
 * select the *Web Integration Service* configuration in the configuration file by adding the ``-cfgName``
 parameter with the name of your selected configuration
 
@@ -64,8 +64,8 @@ For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyWebIntegrationService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/web_integration_service/USER_WEB_INTEGRATION_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyWebIntegrationService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/web_integration_service/USER_WEB_INTEGRATION_SERVICE.xml \
         --name=web_integration_service \
         rticom/web-integration-service:latest \
         -cfgName MyWebIntegrationService
@@ -79,8 +79,8 @@ them to the end of the ``docker run`` command. For example:
 ```
 docker run -dt \
         --network host \
-        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.3.0/rti_license.dat \
-        -v $PWD/MyWebIntegrationService.xml:/home/rtiuser/rti_workspace/7.3.0/user_config/web_integration_service/USER_WEB_INTEGRATION_SERVICE.xml \
+        -v $PWD/rti_license.dat:/opt/rti.com/rti_connext_dds-7.4.0/rti_license.dat \
+        -v $PWD/MyWebIntegrationService.xml:/home/rtiuser/rti_workspace/7.4.0/user_config/web_integration_service/USER_WEB_INTEGRATION_SERVICE.xml \
         --name=web_integration_service \
         rticom/web-integration-service:latest \
         -cfgName MyWebIntegrationService \
@@ -101,7 +101,7 @@ The previous examples use the ``--network host`` parameter to run the containers
 
 If you want to run the containers in a custom network isolated from the host network, you can create a custom network using `docker network create` and run the containers in that network. See the [Docker networking overview documentation](https://docs.docker.com/network/) for more information on Docker networks.
 
-If you  want to make the containers accessible from outside the Docker environment without using the host network, you can expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
+If you  want to make the containers accessible from outside the Docker environment without using the host network, you can expose the necessary UDP ports using the `-p` option. For more information on *RTI Real-Time WAN Transport*, refer to the [User’s Manual](https://community.rti.com/static/documentation/connext-dds/7.4.0/doc/manuals/connext_dds_professional/users_manual/users_manual/PartRealtimeWAN.htm). For more information on the `-p` option, refer to the [Docker running containers documentation](https://docs.docker.com/engine/reference/run/#expose-incoming-ports).
 
 ## Release Notes
 
@@ -120,7 +120,7 @@ Additional third party information can be found at https://community.rti.com/doc
 Use the following command to retrieve the *RTI_License_Agreement.pdf* built-in file:
 
 ```
-docker cp web_integration_service:/opt/rti.com/rti_connext_dds-7.3.0/RTI_License_Agreement.pdf .
+docker cp web_integration_service:/opt/rti.com/rti_connext_dds-7.4.0/RTI_License_Agreement.pdf .
 ```
 
 ## How to get a license file


### PR DESCRIPTION
Copy of internal documentation for 7.4.0 into community documentation for 7.4.0. Done from br-controller ...

```
# on br-controller
#
# pull documentation sources from internal server
#
mkdir -p rti_build/
git clone https://bitbucket.rti.com/scm/connext/connext-containers.git
cd rti_build/connext-containers
git checkout release/connext-container/7.4.0

mkdir -p community/
git clone https://github.com/rticommunity/rticonnextdds-containers.git
#
# on https://github.com/rticommunity/rticonnextdds-containers/branches
#
1. New Branch
    Source: main
    Name: release/7.4.0
git checkout release/7.4.0 && git pull
git checkout -b feature/JH-81-update-docs

cd doc 
for i in `ls` ; do
    cp ~/rti_build/connext-containers/docker/$i/README.md $i/
done
```